### PR TITLE
improve cjk reg

### DIFF
--- a/packages/text/src/CharType.ts
+++ b/packages/text/src/CharType.ts
@@ -13,6 +13,31 @@ const afterChar = '>)]}%!?,.:;\'"' + langAfter
 const symbolChar = afterChar + '_#~&*+\\=|' + langSymbol
 const breakChar = '- ' + langBreak
 
+const cjkRangeList = [
+    [0x4E00, 0x9FFF], // CJK Unified Ideographs
+    [0x3400, 0x4DBF], // CJK Unified Ideographs Extension A
+    [0x20000, 0x2A6DF], // CJK Unified Ideographs Extension B
+    [0x2A700, 0x2B73F], // CJK Unified Ideographs Extension C
+    [0x2B740, 0x2B81F], // CJK Unified Ideographs Extension D
+    [0x2B820, 0x2CEAF], // CJK Unified Ideographs Extension E
+    [0x2CEB0, 0x2EBEF], // CJK Unified Ideographs Extension F
+    [0x30000, 0x3134F], // CJK Unified Ideographs Extension G
+    [0x31350, 0x323AF], // CJK Unified Ideographs Extension H
+    [0x2E80, 0x2EFF], // CJK Radicals Supplement
+    [0x2F00, 0x2FDF], // Kangxi Radicals
+    [0x2FF0, 0x2FFF], // Ideographic Description Characters
+    [0x3000, 0x303F], // CJK Symbols and Punctuation
+    [0x31C0, 0x31EF], // CJK Strokes
+    [0x3200, 0x32FF], // Enclosed CJK Letters and Months
+    [0x3300, 0x33FF], // CJK Compatibility
+    [0xF900, 0xFAFF], // CJK Compatibility Ideographs
+    [0xFE30, 0xFE4F], // CJK Compatibility Forms
+    [0x1F200, 0x1F2FF], // Enclosed Ideographic Supplement
+    [0x2F800, 0x2FA1F], // CJK Compatibility Ideographs Supplement
+]
+
+const cjkReg = new RegExp(cjkRangeList.map(([start, end]) => `[\\u${start.toString(16)}-\\u${end.toString(16)}]`).join('|'))
+
 function mapChar(str: string): IBooleanMap {
     const map: IBooleanMap = {}
     str.split('').forEach(char => map[char] = true)
@@ -42,14 +67,14 @@ export function getCharType(char: string): CharType {
         return Letter
     } else if (breakMap[char]) {
         return Break
-    } else if (/[\u3400-\u9FBF]/.test(char)) { // 4e00-\u9FBF cjk
-        return Single
     } else if (beforeMap[char]) {
         return Before
     } else if (afterMap[char]) {
         return After
     } else if (symbolMap[char]) {
         return Symbol
+    } else if (cjkReg.test(char)) {
+        return Single
     } else {
         return Letter
     }

--- a/packages/text/src/CharType.ts
+++ b/packages/text/src/CharType.ts
@@ -3,8 +3,8 @@ import { IBooleanMap } from '@leafer-ui/interface'
 const money = '¥￥＄€£￡¢￠'
 const letter = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz'
 
-const langBefore = '《（「〈『〖【〔｛┌＜’“＝' + money
-const langAfter = '》）」〉』〗】〕｝┐＞’“！？，、。：；‰'
+const langBefore = '《（「〈『〖【〔｛┌＜‘“＝' + money
+const langAfter = '》）」〉』〗】〕｝┐＞’”！？，、。：；‰'
 const langSymbol = '≮≯≈≠＝…'
 const langBreak = '—／～｜┆·'
 


### PR DESCRIPTION
更新CJK正则判断
参考：https://en.wikipedia.org/wiki/CJK_characters#External_links
把Single判断下移是因为CJK中存在标点符号，优先判断Before与After后再判断CJK。